### PR TITLE
Fix: Use correct my.home-assistant.io OAuth redirect path

### DIFF
--- a/HaLiveNotifications/Utilities/Constants.swift
+++ b/HaLiveNotifications/Utilities/Constants.swift
@@ -11,8 +11,11 @@ struct Constants {
     // MARK: - My Home Assistant OAuth Configuration
     // These URLs are for the production instance of my.home-assistant.io
     static let myHomeAssistantBaseURL = "https://my.home-assistant.io"
-    static let myHomeAssistantAuthorizationURL = "\(myHomeAssistantBaseURL)/oauth2/authorize"
-    static let myHomeAssistantTokenURL = "\(myHomeAssistantBaseURL)/oauth2/token" // This is a guess, needs verification. Actual token endpoint is on the HA instance itself.
+    // Corrected URL for initiating OAuth via My Home Assistant
+    static let myHomeAssistantRedirectOAuthURL = "\(myHomeAssistantBaseURL)/redirect/oauth"
+    // The token URL is not on my.home-assistant.io, but on the user's HA instance.
+    // Example: "http://[YOUR_INSTANCE_URL]/oauth2/token"
+    // This will be constructed dynamically in the app.
 
     // MARK: - OAuth Client Configuration
     // Replace with your actual client ID from Home Assistant registration

--- a/HaLiveNotifications/Views/HomeAssistantLoginView.swift
+++ b/HaLiveNotifications/Views/HomeAssistantLoginView.swift
@@ -88,7 +88,7 @@ struct HomeAssistantLoginView: View {
 
     private func startOAuthFlow() {
         appState.connectionError = nil
-        var components = URLComponents(string: Constants.myHomeAssistantAuthorizationURL)
+        var components = URLComponents(string: Constants.myHomeAssistantRedirectOAuthURL)
         components?.queryItems = [
             URLQueryItem(name: "response_type", value: "code"),
             URLQueryItem(name: "client_id", value: Constants.homeAssistantOAuthClientID),


### PR DESCRIPTION
The my.home-assistant.io service uses `/redirect/oauth` to initiate the OAuth flow, which then redirects to the user's specific Home Assistant instance for authorization. The previous implementation was incorrectly attempting to use `/oauth2/authorize` directly on my.home-assistant.io.

This commit:
- Corrects `myHomeAssistantAuthorizationURL` to `myHomeAssistantRedirectOAuthURL` in `Constants.swift` and updates its value to use the `/redirect/oauth` path.
- Updates `HomeAssistantLoginView.swift` to use the new constant.

This change ensures the OAuth initiation correctly follows the my.home-assistant.io protocol.

(Incorporates previous work on OAuth implementation) Refactor: Switch to Home Assistant OAuth2 for authentication

This commit changes the Home Assistant authentication mechanism from manual long-lived access tokens to the recommended OAuth2 authorization code flow using my.home-assistant.io.

Key changes:
- Removed Bonjour-based local instance discovery (`HomeAssistantDiscoveryService`, `DiscoveredInstance`).
- Updated `HomeAssistantLoginView` to initiate the OAuth2 flow by redirecting to `my.home-assistant.io`.
- Implemented callback handling using a custom URL scheme (`halivenotifications://auth`) to receive the authorization code.
- Added logic to exchange the authorization code for an access token and refresh token directly with the user's Home Assistant instance.
- Updated `HomeAssistantConnection` to store `refreshToken`.
- Modified `HomeAssistantAPIClient` to:
    - Use the stored `HomeAssistantConnection` and `ModelContext`.
    - Automatically refresh the access token using the refresh token when a 401 Unauthorized error occurs.
    - Persist the new tokens after a successful refresh.
- Updated `AppState` to correctly manage and inject `ModelContext` into `HomeAssistantAPIClient`.
- Added the necessary URL scheme to `Info.plist`.
- Defined OAuth related constants in `Constants.swift` (using placeholders for Client ID).