### PR TITLE
Refactor: Store pending OAuth state and PKCE verifier in AppState

### DIFF
--- a/HaLiveNotifications/AppState.swift
+++ b/HaLiveNotifications/AppState.swift
@@ -29,6 +29,10 @@ class AppState {
     var isLoading: Bool = false
     var connectionError: HAErrors?
 
+    // Properties to hold temporary OAuth state during the flow
+    var pendingOAuthState: String?
+    var pendingPkceCodeVerifier: String?
+
     // MARK: - Initialization
     init() {
         // Initial apiClient will be nil until a connection is loaded/established
@@ -125,5 +129,12 @@ class AppState {
             self.currentConnection = nil
             self.isLoading = false
         }
+    }
+
+    // MARK: - OAuth State Management
+    func clearPendingOAuthData() {
+        pendingOAuthState = nil
+        pendingPkceCodeVerifier = nil
+        print("Cleared pending OAuth state and PKCE verifier from AppState.")
     }
 }


### PR DESCRIPTION
To improve the reliability of the OAuth flow, especially when app switching occurs (e.g., redirecting via an external browser or another app like the Home Assistant companion app), this commit moves the temporary storage of the `state` parameter and the PKCE `code_verifier` from `HomeAssistantLoginView`'s local state to `AppState`.

Changes:
- Added `pendingOAuthState` and `pendingPkceCodeVerifier` properties to `AppState`.
- Added `clearPendingOAuthData()` method to `AppState`.
- `HomeAssistantLoginView` now uses these `AppState` properties to store and retrieve these values during the OAuth authorization and token exchange processes.
- Removed local state management for these parameters from `HomeAssistantLoginView`.

This makes the `state` validation and `code_verifier` availability more resilient across app lifecycle events during the OAuth redirect dance.

(Incorporates previous work on PKCE, state, OAuth redirect path fix, and initial OAuth implementation) Feat: Implement PKCE and state parameter for OAuth flow Fix: Use correct my.home-assistant.io OAuth redirect path Refactor: Switch to Home Assistant OAuth2 for authentication